### PR TITLE
update podspec: add data plist resources file

### DIFF
--- a/MMLanScan.podspec
+++ b/MMLanScan.podspec
@@ -22,4 +22,5 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/mavris/MMLanScan.git', :tag => s.version.to_s }
   s.ios.deployment_target = '8.0'
   s.source_files = 'MMLanScan/**/*.{h,m}'
+  spec.resources = 'MMLanScan/Data/data.plist'
 end


### PR DESCRIPTION
using CocoaPods: can't  get the brand name from mac adresse 
need to add data plist resources file on podspec file