### PR TITLE
Fix crash

### DIFF
--- a/MMLanScan/External Libs/SimplePing/SimplePing.m
+++ b/MMLanScan/External Libs/SimplePing/SimplePing.m
@@ -611,7 +611,6 @@ static void HostResolveCallback(CFHostRef theHost, CFHostInfoType typeInfo, cons
 {
     if (self->_socket != NULL) {
         CFSocketInvalidate(self->_socket);
-        CFRelease(self->_socket);
         self->_socket = NULL;
     }
 }


### PR DESCRIPTION
Monitored lot of crash due this line: `CFRelease(self->_socket);`
CFSocketInvalidate may have released self->_socket already.